### PR TITLE
Fix Extension Detection and ECM Handling

### DIFF
--- a/core/converter.py
+++ b/core/converter.py
@@ -4,7 +4,8 @@ import threading
 import shutil
 from typing import Callable
 from core.detector import (
-    get_chdman_path, get_tool_path, detect_file, get_valid_targets
+    get_chdman_path, get_tool_path, detect_file, get_valid_targets,
+    get_extension, get_output_name
 )
 from core.logger import log as global_log
 from core.validator import verify_chd
@@ -202,35 +203,24 @@ class Converter:
 
     def _to_ecm(self, job: ConversionJob, src: str) -> bool:
         ecm = get_tool_path("ecm")
-        out = self._out_path(job, src, os.path.splitext(src)[1] + ".ecm")
+        out = self._out_path(job, src, "ecm")
         cmd = [ecm, src, out]
         self._log(f"[ECM] {os.path.basename(src)} → {os.path.basename(out)}")
         return self._run(cmd, job)
 
     def _from_ecm(self, job: ConversionJob, src: str, tgt: str) -> bool:
         unecm = get_tool_path("unecm")
-        base = os.path.basename(src)
-        if base.lower().endswith(".ecm"):
-            base = base[:-4]
-
-        # Determine output format after unecm extraction
-        inner_ext = os.path.splitext(base)[1].lower()
-        if not inner_ext:
-            inner_ext = ".iso" if tgt == "ISO" else ".bin"
-            base = base + inner_ext
-
-        out = os.path.join(job.output_dir, base)
+        out = self._out_path(job, src, tgt)
         cmd = [unecm, src, out]
         self._log(f"[UNECM] {os.path.basename(src)} → {os.path.basename(out)}")
 
         ok = self._run(cmd, job)
         if ok and os.path.isfile(out):
             # Auto-detect format of extracted file and rename if requested format differs
-            detected = detect_file(out)
-            ext_found = os.path.splitext(out)[1].lower()
-            target_ext = f".{tgt.lower()}"
-            if target_ext in (".iso", ".bin") and ext_found != target_ext:
-                new_out = os.path.splitext(out)[0] + target_ext
+            ext_found = get_extension(out)
+            target_ext = tgt.lower()
+            if target_ext in ("iso", "bin") and ext_found != target_ext:
+                new_out = os.path.join(job.output_dir, get_output_name(os.path.basename(out), target_ext))
                 try:
                     shutil.move(out, new_out)
                     self._log(f"[UNECM AUTO-DETECT] Renamed output to: {os.path.basename(new_out)}")
@@ -250,7 +240,7 @@ class Converter:
     def _xiso_to_iso(self, job: ConversionJob, src: str) -> bool:
         """XISO → ISO via extract-xiso -x"""
         xiso = get_tool_path("xiso")
-        base = os.path.splitext(os.path.basename(src))[0]
+        base = os.path.basename(src).rsplit('.', 1)[0]
         out_dir = os.path.join(job.output_dir, base)
         cmd  = [xiso, "-x", src, "-d", out_dir]
         self._log(f"[XISO→ISO] Extracting XISO {os.path.basename(src)} to {out_dir}...")
@@ -294,8 +284,8 @@ class Converter:
             return False
 
     def _out_path(self, job: ConversionJob, src: str, ext: str) -> str:
-        base = os.path.splitext(os.path.basename(src))[0]
-        return os.path.join(job.output_dir, base + ext)
+        out_name = get_output_name(os.path.basename(src), ext)
+        return os.path.join(job.output_dir, out_name)
 
     def _log(self, msg: str):
         global_log(msg)
@@ -314,7 +304,7 @@ class Converter:
                 pass
 
     def _auto_cue(self, bin_path: str, output_dir: str) -> str | None:
-        base = os.path.splitext(os.path.basename(bin_path))[0]
+        base = os.path.basename(bin_path).rsplit('.', 1)[0]
         cue_path = os.path.join(output_dir, base + "_auto.cue")
         bin_name = os.path.basename(bin_path)
         try:

--- a/core/detector.py
+++ b/core/detector.py
@@ -75,6 +75,16 @@ COMMAND_TEMPLATES = {
     ("XISO", "ISO"): "extract-xiso -x \"{in}\" -d \"{out}\"",
 }
 
+def get_extension(filename: str) -> str:
+    return filename.lower().rsplit('.', 1)[-1]
+
+def get_output_name(input_file: str, new_ext: str) -> str:
+    clean_ext = new_ext.lstrip('.')
+    base = input_file.rsplit('.', 1)[0]
+    if base.lower().endswith(f".{clean_ext.lower()}"):
+        return base
+    return f"{base}.{clean_ext}"
+
 def get_badge_color(fmt: str) -> str:
     return FORMAT_COLORS.get(fmt.upper(), FORMAT_COLORS["UNKNOWN"])
 
@@ -87,9 +97,8 @@ def get_command_preview(fmt: str, target: str, filename: str = "game.iso") -> st
     if not template:
         return f"{fmt} -> {target}"
 
-    base = os.path.splitext(filename)[0]
-    out_ext = f".{target.lower().replace('/cue', '')}"
-    out = base + out_ext
+    out = get_output_name(filename, target.lower().replace('/cue', ''))
+    base = filename.rsplit('.', 1)[0]
     cue = base + ".cue"
 
     return template.format(
@@ -100,18 +109,13 @@ def detect_file(filepath: str) -> dict:
     if not os.path.isfile(filepath):
         return {"error": f"File not found: {filepath}"}
 
-    name = os.path.basename(filepath).lower()
-    ext = os.path.splitext(name)[1]
+    name = os.path.basename(filepath)
+    ext_str = get_extension(name)
+    ext = f".{ext_str}"
     size = os.path.getsize(filepath)
 
-    needs_ecm = False
-    real_ext = ext
-    if ext == ".ecm":
-        needs_ecm = True
-        inner = os.path.splitext(os.path.splitext(name)[0])[1]
-        real_ext = inner if inner in SUPPORTED_INPUT else ".ecm"
-
-    fmt = SUPPORTED_INPUT.get(real_ext, "UNKNOWN")
+    fmt = SUPPORTED_INPUT.get(ext, "UNKNOWN")
+    needs_ecm = (fmt == "ECM")
     plat = _guess_platform(filepath, fmt, size)
 
     chd_type = None
@@ -149,7 +153,7 @@ def detect_folder(folder: str) -> list:
         fpath = os.path.join(folder, fname)
         if not os.path.isfile(fpath):
             continue
-        ext = os.path.splitext(fname.lower())[1]
+        ext = f".{get_extension(fname)}"
         if ext in SUPPORTED_INPUT:
             info = detect_file(fpath)
             info["filepath"] = fpath
@@ -187,8 +191,8 @@ def _guess_chd_type(size: int) -> str:
     return "cd" if mb < 900 else "dvd"
 
 def _find_pair(filepath: str, target_ext: str) -> str | None:
-    base = os.path.splitext(filepath)[0]
-    candidate = base + target_ext
+    base = filepath.rsplit('.', 1)[0]
+    candidate = base + (target_ext if target_ext.startswith('.') else f".{target_ext}")
     return candidate if os.path.isfile(candidate) else None
 
 def _human_size(size: int) -> str:

--- a/test_detector.py
+++ b/test_detector.py
@@ -1,0 +1,44 @@
+import os
+import tempfile
+import unittest
+from core.detector import get_extension, get_output_name, detect_file
+
+class TestDetector(unittest.TestCase):
+    def test_get_extension(self):
+        self.assertEqual(get_extension("tom_jerry.bin.ecm"), "ecm")
+        self.assertEqual(get_extension("game.iso"), "iso")
+        self.assertEqual(get_extension("disc.cue"), "cue")
+        self.assertEqual(get_extension("archive.tar.gz"), "gz")
+
+    def test_get_output_name(self):
+        self.assertEqual(get_output_name("tom_jerry.bin.ecm", "bin"), "tom_jerry.bin")
+        self.assertEqual(get_output_name("tom_jerry.bin.ecm", ".bin"), "tom_jerry.bin")
+        self.assertEqual(get_output_name("game.iso", "chd"), "game.chd")
+        self.assertEqual(get_output_name("disc.bin", "ecm"), "disc.ecm")
+
+    def test_detect_file_cases(self):
+        cases = [
+            ("tom_jerry.bin.ecm", "ECM", ["ISO", "BIN"]),
+            ("game.iso", "ISO", ["CHD", "CSO", "ECM", "XISO"]),
+            ("disc.bin", "BIN", ["CHD", "ECM"]),
+            ("disc.cue", "CUE", ["CHD"]),
+            ("sonic.gdi", "GDI", ["CHD"]),
+            ("halo.chd", "CHD", ["ISO", "BIN/CUE"]),
+            ("psp_game.cso", "CSO", ["ISO"]),
+            ("psp_game.zso", "ZSO", ["ISO"]),
+            ("xbox_iso.iso", "ISO", ["CHD", "CSO", "ECM", "XISO"]),
+        ]
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            for filename, expected_fmt, expected_targets in cases:
+                filepath = os.path.join(tmpdir, filename)
+                with open(filepath, "wb") as f:
+                    f.write(b"\x00" * 1024)
+
+                res = detect_file(filepath)
+                self.assertNotIn("error", res)
+                self.assertEqual(res["format"], expected_fmt, f"Failed format check for {filename}")
+                self.assertEqual(res["valid_targets"], expected_targets, f"Failed targets check for {filename}")
+
+if __name__ == "__main__":
+    unittest.main()

--- a/ui/drag_drop.py
+++ b/ui/drag_drop.py
@@ -1,6 +1,7 @@
 import os
 import customtkinter as ctk
 from tkinter import filedialog
+from core.detector import get_extension
 
 BG_DARK     = "#1a1a2e"
 CARD_BG     = "#16213e"
@@ -97,7 +98,7 @@ class DragDropFrame(ctk.CTkFrame):
             if os.path.isdir(p) and self.on_folder:
                 self.on_folder(p)
             elif os.path.isfile(p):
-                ext = os.path.splitext(p)[1].lower()
+                ext = f".{get_extension(p)}"
                 if self.accepted_exts is None or ext in self.accepted_exts:
                     valid.append(p)
         if valid and self.on_files:

--- a/ui/main_window.py
+++ b/ui/main_window.py
@@ -7,7 +7,10 @@ from tkinter import filedialog, StringVar, messagebox
 from ui.drag_drop import DragDropFrame
 from ui.settings import SettingsWindow
 from ui.about import AboutWindow
-from core.detector import detect_file, detect_folder, SUPPORTED_INPUT, get_valid_targets, get_command_preview, get_badge_color
+from core.detector import (
+    detect_file, detect_folder, SUPPORTED_INPUT, get_valid_targets,
+    get_command_preview, get_badge_color, get_extension
+)
 from core.converter import Converter, ConversionJob
 from core.validator import verify_chd
 from core.logger import log
@@ -316,7 +319,7 @@ class MainWindow(ctk.CTk):
         with self._jobs_lock:
             existing = {j.filepath for j in self.jobs}
             for p in paths:
-                ext = os.path.splitext(p)[1].lower()
+                ext = f".{get_extension(p)}"
                 if ext not in SUPPORTED_INPUT or p in existing:
                     continue
                 info = detect_file(p)


### PR DESCRIPTION
Resolved double extension detection issue by implementing get_extension and get_output_name helper functions. Updated ECM handling and conversion targets, preventing duplicated extension outputs (e.g. bin.bin), and added comprehensive unit tests.

---
*PR created automatically by Jules for task [16256477620780222055](https://jules.google.com/task/16256477620780222055) started by @ClausValcaTD*