### PR TITLE
fix: resolve ISO->CHD command selection and Xbox magic detection

### DIFF
--- a/core/converter.py
+++ b/core/converter.py
@@ -150,7 +150,7 @@ class Converter:
             sub_cmd = "createcd"
         elif fmt in ("ISO", "IMG"):
             platform = info.get("platform", "")
-            sub_cmd = "createcd" if "PS1" in platform else "createdvd"
+            sub_cmd = "createcd" if platform in ("PS1", "Dreamcast") else "createdvd"
         else:
             sub_cmd = "createcd"
 

--- a/core/detector.py
+++ b/core/detector.py
@@ -124,8 +124,9 @@ _WII_MAGIC  = 0x5D1C9EA3
 _CD_SYNC    = b'\x00' + b'\xff' * 10 + b'\x00'
 
 # Xbox XDVDFS magic
-_XBOX_MAGIC         = b"MICROSOFT*XBOX*MEDIA"
-_XBOX_OFFSETS       = [0x10000, 0x2090000]
+_XBOX_MAGIC    = b"MICROSOFT*XBOX*MEDIA"
+_XBOX_OFFSET_1 = 0x10000
+_XBOX_OFFSET_2 = 0x2090000
 
 
 # ── Public helpers ───────────────────────────────────────────────────────────
@@ -258,9 +259,12 @@ def _guess_platform(filepath: str, fmt: str, size: int, header: bytes) -> str:
         return "Xbox"
 
     if fmt in ("ISO", "BIN", "IMG", "CUE"):
-        # Xbox: XDVDFS magic at fixed sector offsets (only readable for ISO/IMG)
-        if fmt in ("ISO", "IMG") and _header_has_xbox_magic(header):
-            return "Xbox"
+        # Xbox check — try fast path first, then slow seek
+        if fmt in ("ISO", "IMG"):
+            if _header_has_xbox_magic(header):
+                return "Xbox"
+            if _file_has_xbox_magic_slow(filepath):
+                return "Xbox"
 
         # PSP: UMD_DATA / PSP_GAME marker in first 64 KB
         if fmt in ("ISO", "IMG") and _header_has_psp_magic(header):
@@ -295,11 +299,18 @@ def _guess_platform(filepath: str, fmt: str, size: int, header: bytes) -> str:
 
 
 def _header_has_xbox_magic(header: bytes) -> bool:
-    """Check XDVDFS magic at offset 0x10000. Offset 0x2090000 requires a seek — skipped here."""
-    offset = 0x10000
-    if len(header) >= offset + 20:
-        return header[offset:offset + 20] == _XBOX_MAGIC
-    return False
+    """Fast path — checks offset 0x10000 from preloaded header."""
+    return header[_XBOX_OFFSET_1:_XBOX_OFFSET_1 + len(_XBOX_MAGIC)] == _XBOX_MAGIC
+
+
+def _file_has_xbox_magic_slow(filepath: str) -> bool:
+    """Slow path — seeks to offset 0x2090000 for Xbox 360 / alt layout ISOs."""
+    try:
+        with open(filepath, "rb") as f:
+            f.seek(_XBOX_OFFSET_2)
+            return f.read(len(_XBOX_MAGIC)) == _XBOX_MAGIC
+    except Exception:
+        return False
 
 
 def _header_has_psp_magic(header: bytes) -> bool:

--- a/test_detector.py
+++ b/test_detector.py
@@ -40,5 +40,27 @@ class TestDetector(unittest.TestCase):
                 self.assertEqual(res["format"], expected_fmt, f"Failed format check for {filename}")
                 self.assertEqual(res["valid_targets"], expected_targets, f"Failed targets check for {filename}")
 
+    def test_xbox_magic_detection(self):
+        xbox_magic = b"MICROSOFT*XBOX*MEDIA"
+        with tempfile.TemporaryDirectory() as tmpdir:
+            # Fast path (offset 0x10000)
+            fast_path = os.path.join(tmpdir, "xbox_fast.iso")
+            with open(fast_path, "wb") as f:
+                f.write(b"\x00" * 0x10000)
+                f.write(xbox_magic)
+                f.write(b"\x00" * 1024)
+
+            res_fast = detect_file(fast_path)
+            self.assertEqual(res_fast["platform"], "Xbox")
+
+            # Slow path (offset 0x2090000)
+            slow_path = os.path.join(tmpdir, "xbox_slow.iso")
+            with open(slow_path, "wb") as f:
+                f.seek(0x2090000)
+                f.write(xbox_magic)
+
+            res_slow = detect_file(slow_path)
+            self.assertEqual(res_slow["platform"], "Xbox")
+
 if __name__ == "__main__":
     unittest.main()

--- a/test_tools.py
+++ b/test_tools.py
@@ -181,3 +181,24 @@ def test_header_remover():
 
         clean_snes = remove_header(snes_file, backup=False)
         assert os.path.getsize(clean_snes) == 1024
+
+
+def test_iso_to_chd_command_selection():
+    from core.converter import Converter, ConversionJob
+    class TestConverter(Converter):
+        def _run(self, cmd, job):
+            self.last_cmd = cmd
+            return True
+
+    c = TestConverter()
+    job = ConversionJob('ps1_game.iso', '/tmp', 'CHD')
+    c._to_chd(job, 'ps1_game.iso', 'ISO', {'platform': 'PS1'})
+    assert c.last_cmd[1] == 'createcd'
+
+    job = ConversionJob('dc_game.iso', '/tmp', 'CHD')
+    c._to_chd(job, 'dc_game.iso', 'ISO', {'platform': 'Dreamcast'})
+    assert c.last_cmd[1] == 'createcd'
+
+    job = ConversionJob('ps2_game.iso', '/tmp', 'CHD')
+    c._to_chd(job, 'ps2_game.iso', 'ISO', {'platform': 'PS2'})
+    assert c.last_cmd[1] == 'createdvd'


### PR DESCRIPTION
- Fix Bug #1: Ensure ISO->CHD conversion uses `createcd` for PS1 and Dreamcast platforms in `core/converter.py`.
- Fix Bug #2: Add slow-path Xbox magic detection at offset `0x2090000` via file seek in `core/detector.py`.
- Add test coverage for both fixes in `test_tools.py` and `test_detector.py`.

---
*PR created automatically by Jules for task [12583250327909891821](https://jules.google.com/task/12583250327909891821) started by @ClausValcaTD*